### PR TITLE
Remover background indevido

### DIFF
--- a/_layouts/saibamais.html
+++ b/_layouts/saibamais.html
@@ -10,7 +10,10 @@
 <head>
     {% include common/meta.html %}
     <link href='{{ site.baseurl }}/assets/stylesheets/blog.css' rel="stylesheet" type="text/css">
-    <link href='{{ site.baseurl }}/assets/stylesheets/nos-por-nos.css' rel="stylesheet" type="text/css">
+    {% if page.css %}
+    <link href='{{ site.baseurl }}/assets/stylesheets/{{ page.css }}' rel="stylesheet" type="text/css">
+    {% endif %}
+
     {% include common/libraries.html %}
     {% if site.google_tag_manager %}
         {% include common/gtm-head.html %}


### PR DESCRIPTION
No ultimo merge, acabou aplicando o css do Nos por Nos em outras paginas.

Aqui vai a correção