### PR TITLE
Publicando o site automagicamente

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,15 @@
+version: 2.1
+orbs:
+  ruby: circleci/ruby@0.1.2 
+
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.6.3-stretch-node
+    executor: ruby/default
+    steps:
+      - checkout
+      - run:
+          name: Which bundler?
+          command: bundle -v
+      - ruby/bundle-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,6 @@ orbs:
 
 jobs:
   build:
-    filters:
-      branches:
-        only: master
     docker:
       - image: circleci/ruby:2.6.3-stretch-node
     executor: ruby/default
@@ -28,3 +25,11 @@ jobs:
       - run:
           name: Publicar o site
           command: sh scripts/publicar.sh
+workflows:
+  version: 2
+  build_and_publish:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ orbs:
 
 jobs:
   build:
+    filters:
+      branches:
+        only: master
     docker:
       - image: circleci/ruby:2.6.3-stretch-node
     executor: ruby/default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ jobs:
     executor: ruby/default
     steps:
       - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "59:1a:9c:ab:5e:b5:69:74:ce:44:f4:61:ff:a1:33:c5"
       - run:
           name: Instalar Bundler
           command: gem install bundler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,3 +13,12 @@ jobs:
           name: Instalar Bundler
           command: gem install bundler
       - ruby/bundle-install
+      - run:
+          name: Criar diretorio para o site
+          command: mkdir -p /tmp/site
+      - run:
+          name: Gerar o site
+          command: bundle exec jekyll build --destination /tmp/site
+      - run:
+          name: Publicar o site
+          command: sh scripts/publicar.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby: circleci/ruby@0.1.2 
+  ruby: circleci/ruby@0.1.2
 
 jobs:
   build:
@@ -10,6 +10,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Which bundler?
-          command: bundle -v
+          name: Instalar Bundler
+          command: gem install bundler
       - ruby/bundle-install

--- a/scripts/publicar.sh
+++ b/scripts/publicar.sh
@@ -10,7 +10,7 @@ setup_git() {
 comitar() {
   echo 'Comitar o site'
   git checkout -b gh-pages
-  mv /tmp/site/* .
+  cp -r /tmp/site/* .
   git add .
   git commit --message "Automagicamente publicando n# $CIRCLE_BUILD_NUM"
 }

--- a/scripts/publicar.sh
+++ b/scripts/publicar.sh
@@ -17,7 +17,7 @@ comitar() {
 
 publicar() {
   echo 'Publicando o site'
-  git push --quiet --set-upstream origin-pages gh-pages
+  git push --quiet --set-upstream origin gh-pages
 }
 
 setup_git

--- a/scripts/publicar.sh
+++ b/scripts/publicar.sh
@@ -22,6 +22,6 @@ publicar() {
   git push --quiet --set-upstream origin-pages gh-pages
 }
 
-setup_git()
-comitar()
-publicar()
+setup_git
+comitar
+publicar

--- a/scripts/publicar.sh
+++ b/scripts/publicar.sh
@@ -5,12 +5,13 @@ setup_git() {
   echo 'Configurar o git'
   git config --global user.email "robozin@circleci.com"
   git config --global user.name "Maquina Viva"
+  git checkout -b gh-pages
+  git pull --rebase origin gh-pages
 }
 
 comitar() {
   echo 'Comitar o site'
-  git checkout -b gh-pages
-  cp -r /tmp/site/* .
+  mv -u /tmp/site/* .
   git add .
   git commit --message "Automagicamente publicando n# $CIRCLE_BUILD_NUM"
 }

--- a/scripts/publicar.sh
+++ b/scripts/publicar.sh
@@ -1,0 +1,27 @@
+#! /bin/sh
+
+
+setup_git() {
+  echo 'Configurar o git'
+  git config --global user.email "robozin@circleci.com"
+  git config --global user.name "Maquina Viva"
+  cd /tmp/site
+  git init
+  git remote add origin-pages "$CIRCLE_REPOSITORY_URL" > /dev/null 2>&1
+}
+
+comitar() {
+  echo 'Comitar o site'
+  git checkout -b gh-pages
+  git add .
+  git commit --message "Automagicamente publicando n# $CIRCLE_BUILD_NUM"
+}
+
+publicar() {
+  echo 'Publicando o site'
+  git push --quiet --set-upstream origin-pages gh-pages
+}
+
+setup_git()
+comitar()
+publicar()

--- a/scripts/publicar.sh
+++ b/scripts/publicar.sh
@@ -5,14 +5,12 @@ setup_git() {
   echo 'Configurar o git'
   git config --global user.email "robozin@circleci.com"
   git config --global user.name "Maquina Viva"
-  cd /tmp/site
-  git init
-  git remote add origin-pages "$CIRCLE_REPOSITORY_URL" > /dev/null 2>&1
 }
 
 comitar() {
   echo 'Comitar o site'
   git checkout -b gh-pages
+  mv /tmp/site/* .
   git add .
   git commit --message "Automagicamente publicando n# $CIRCLE_BUILD_NUM"
 }


### PR DESCRIPTION
Como Github Pages ignora plugins e atualmente o site precisa de um plugin, [Polyglot](polyglot.untra.io/) para cuidar da internacionalização, configurei o projeto no CircleCI, que é uma plataforma de automatização de deploy.
Agora, cada vez que fizermos commit no master, o [CircleCI](https://app.circleci.com/pipelines/github/portalsemporteiras/portalsemporteiras.github.io) vai cuidar de gerar o site pra gente na branch gh-pages.